### PR TITLE
Allow wildcard media types.

### DIFF
--- a/lib/mediaType.js
+++ b/lib/mediaType.js
@@ -82,7 +82,7 @@ var unwrapQuotes = function(str) {
   return (str.substr(0, 1) === '"' && str.substr(-1) === '"') ? str.substr(1, str.length - 2) : str;
 };
 
-var mediaTypeMatcher = /^(application|audio|image|message|model|multipart|text|video)\/([a-zA-Z0-9!#$%^&\*_\-\+{}\|'.`~]{1,127})(;.*)?$/;
+var mediaTypeMatcher = /^(application|audio|image|message|model|multipart|text|video|\*)\/([a-zA-Z0-9!#$%^&\*_\-\+{}\|'.`~]{1,127})(;.*)?$/;
 
 var parameterSplitter = /;(?=(?:[^\"]*\"[^\"]*\")*(?![^\"]*\"))/;
 

--- a/lib/mediaType.js
+++ b/lib/mediaType.js
@@ -90,7 +90,7 @@ exports.fromString = function(str) {
   var mediaType = new MediaType();
   if (str) {
     var match = str.match(mediaTypeMatcher);
-    if (match) {
+    if (match && !(match[1] === '*' && match[2] !== '*')) { 
       mediaType.type = match[1];
       mediaType._setSubtypeAndSuffix(match[2]);
       if (match[3]) {

--- a/test/unit.js
+++ b/test/unit.js
@@ -65,7 +65,11 @@ var mediaType = require("../lib/mediaType");
   "text/xml; subtype=gml/3.1.1",
 
   // https://twitter.com/fcw/status/398604109525184512
-  "application/LD+JSON-SQL*CSV.1"
+  "application/LD+JSON-SQL*CSV.1",
+
+  // wildcards from http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.1
+  "*/*",
+  "audio/*"
 
 ].forEach(function(value) {
   var type = mediaType.fromString(value);
@@ -85,6 +89,8 @@ var mediaType = require("../lib/mediaType");
   "text/(plain)",
   "text/@plain",
   "text/plain,wrong",
+  "*",
+  "*/plain",
 
   // https://bugs.launchpad.net/kde-baseapps/+bug/570832
   "fonts/package",


### PR DESCRIPTION
This is to allow for handling of HTTP Accepts headers that employ a wildcard matcher (usually along with a `q` < 1 parameter).